### PR TITLE
add a new dataset class miscGFFToWebService to the organismSpecificMi…

### DIFF
--- a/Main/lib/perl/WorkflowSteps/CopyGFF3ToWebServiceDir.pm
+++ b/Main/lib/perl/WorkflowSteps/CopyGFF3ToWebServiceDir.pm
@@ -39,7 +39,7 @@ sub run {
   } else {
     $self->runCmd($test, $cmd_mkdir);
     $self->runCmd($test, $cmd_copy);
-    $self->runCmd($test, "cp $workflowDataDir/$gff3File.tbi $copyToDir");
+    $self->runCmd($test, "cp $workflowDataDir/$gff3File.tbi $copyToDir") unless($self->getParamValue('copyGFFOnly') =~ /true/i);
   }
 
 }

--- a/Main/lib/xml/workflowTemplates/organismSpecificMiscNoAlias.xml
+++ b/Main/lib/xml/workflowTemplates/organismSpecificMiscNoAlias.xml
@@ -267,6 +267,32 @@
     </subgraph>
   </datasetTemplate> -->
 
+
+  <datasetTemplate class="miscGFFToWebService">
+    <prop name="projectName"/>
+    <prop name="organismAbbrev"/>
+    <prop name="name"/>
+    <prop name="version"/>
+    <prop name="copyGFFOnly"/>
+
+    <subgraph name="${name}_miscGFFToWebService" xmlFile="loadDataset.xml">
+      <paramValue name="datasetName">${organismAbbrev}_${name}_miscGFFToWebService_RSRC</paramValue>
+      <paramValue name="gusConfigFile">$$gusConfigFile$$</paramValue>
+      <paramValue name="datasetLoaderXmlFileName">$$organismDatasetLoaderXmlFile$$</paramValue>
+      <paramValue name="parentDataDir">$$dataDir$$</paramValue>
+    </subgraph>
+
+    <step name="${name}_miscGFFToWebService_copyGFF3ToWebServiceDir" stepClass="ApiCommonWorkflow::Main::WorkflowSteps::CopyGFF3ToWebServiceDir">
+      <paramValue name="gusConfigFile">$$gusConfigFile$$</paramValue>
+      <paramValue name="gff3File">$$dataDir$$/${organismAbbrev}_${name}_miscGFFToWebService_RSRC/final/${organismAbbrev}_${name}.gff</paramValue>
+      <paramValue name="organismAbbrev">${organismAbbrev}</paramValue>
+      <paramValue name="relativeDir">$$relativeWebServicesDir$$</paramValue>
+      <paramValue name="experimentDatasetName">${name}</paramValue>
+      <paramValue name="copyGFFOnly">${copyGFFOnly}</paramValue>
+      <depends name="${name}_miscGFFToWebService"/>
+    </step>
+
+  </datasetTemplate>
 </workflowGraph>
 
 


### PR DESCRIPTION
…scNoAlias.xml template, It uses loadDataset.xml to copy a GFF file from the manual delivery dir to the workflow data dir and then loads Nothing. After that, it uses an existing workflow step, CopyGFF3ToWebServiceDir (with a minor modification), to copy the GFF file from the workflow data dir to the webService dir