### PR TITLE
Remove insertPubmedDbXrefs step from dbxrefs.xml

### DIFF
--- a/Main/lib/xml/workflow/dbxrefs.xml
+++ b/Main/lib/xml/workflow/dbxrefs.xml
@@ -47,19 +47,16 @@
   </step>
 
 
-
-  
-  <step name="insertPubmedDbXrefs" stepClass="ApiCommonWorkflow::Main::WorkflowSteps::InsertDBxRefs">
-    <paramValue name="inputFile">$$dataDir$$/associatedGenes/pubmed_mappings.txt</paramValue>
-    <paramValue name="extDbName">Gene2Pubmed_RSRC</paramValue>
-    <paramValue name="extDbVersion">%</paramValue>
-    <paramValue name="tableName">DbRefNAFeature</paramValue>
-    <paramValue name="viewName">GeneFeature</paramValue>
-    <paramValue name="organismAbbrev">$$organismAbbrev$$</paramValue>
-    <paramValue name="genomeExtDbRlsSpec">$$genomeExtDbRlsSpec$$</paramValue>
-    <paramValue name="gusConfigFile">$$gusConfigFile$$</paramValue>
-    <depends name="associateGenesWithDbXrefs"/>
-  </step>
+  <!--
+    The insertPubmedDbXrefs step has been removed. It loaded NCBI gene2pubmed
+    associations into SRes.DbRef + DoTS.DbRefNAFeature under
+    external_database_release_id = Gene2Pubmed_RSRC. After review, those
+    associations were determined to add no useful biological insight to gene
+    pages: the references are generic and apply the same paper to large
+    numbers of unrelated genes. Curator- and Apollo-submitted PubMed refs
+    (which DO add value) come in via ISF under the PMID/PubMed external
+    database and are unaffected.
+  -->
 
   <step name="insertUniprotDbXrefs" stepClass="ApiCommonWorkflow::Main::WorkflowSteps::InsertDBxRefs">
     <paramValue name="inputFile">$$dataDir$$/associatedGenes/uniprot_mappings.txt</paramValue>


### PR DESCRIPTION
NCBI gene2pubmed associations were loaded into SRes.DbRef + DoTS.DbRefNAFeature under external_database_release_id = Gene2Pubmed_RSRC and surfaced in the Literature section of gene pages. After review, these associations were determined to add no useful biological insight: the references are generic and apply the same paper to large numbers of unrelated genes, often redundantly and never with curatorial value to the user.

This change stops loading them on subsequent workflow runs. Existing rows under Gene2Pubmed_RSRC will be removed by a separate, scoped DBA cleanup that does not affect any other dbxref class.

Curator- and Apollo-submitted PubMed references are not affected: they enter through ISF under the PMID/PubMed ExternalDatabase, with a different external_database_release_id, and use a different code path (SpecialCaseQualifierHandlers::literature).

The upstream associateGenesWithDbXrefs script and its workflow-step wrapper still generate pubmed_mappings.txt; that file is now orphaned and a follow-up PR will prune the unused upstream code path. Leaving it in place for this PR keeps the change minimal and the diff easy to review.