### PR TITLE
Add UndoEdaStudy step to remove EDA metadata before undoing a single rnaSeq dataset

### DIFF
--- a/Main/lib/perl/WorkflowSteps/UndoEdaStudy.pm
+++ b/Main/lib/perl/WorkflowSteps/UndoEdaStudy.pm
@@ -1,0 +1,25 @@
+package ApiCommonWorkflow::Main::WorkflowSteps::UndoEdaStudy;
+
+@ISA = (ApiCommonWorkflow::Main::WorkflowSteps::WorkflowStep);
+
+use strict;
+use ApiCommonWorkflow::Main::WorkflowSteps::WorkflowStep;
+
+sub run {
+  my ($self, $test, $undo) = @_;
+
+  my $extDbRlsSpec  = $self->getParamValue('extDbRlsSpec');
+  my $gusConfigFile = $self->getParamValue('gusConfigFile');
+
+  my $workflowDataDir = $self->getWorkflowDataDir();
+  my $logFile = "$workflowDataDir/undoEdaStudy.log";
+
+  if ($undo) {
+    $self->runCmd($test, "undoEdaStudy.pl --extDbRlsSpec '$extDbRlsSpec' --gusConfigFile $gusConfigFile");
+    $self->runCmd(0, "rm -f $logFile");
+  } else {
+    $self->runCmd($test, "echo 'EDA study metadata loaded for $extDbRlsSpec' > $logFile");
+  }
+}
+
+1;

--- a/Main/lib/xml/workflowTemplates/rnaseq.xml
+++ b/Main/lib/xml/workflowTemplates/rnaseq.xml
@@ -103,6 +103,13 @@
           <depends name="dumpPseudogenes"/>
           <depends name="${name}_ebi_rnaSeq_loadDataset"/>
       </subgraph>
+
+      <step name="${name}_ebi_rnaSeq_undoEdaStudy"
+            stepClass="ApiCommonWorkflow::Main::WorkflowSteps::UndoEdaStudy">
+          <paramValue name="extDbRlsSpec">${organismAbbrev}_${name}_ebi_rnaSeq_RSRC|${version}</paramValue>
+          <paramValue name="gusConfigFile">$$gusConfigFile$$</paramValue>
+          <depends name="${name}_ebi_rnaSeq_experiment"/>
+      </step>
     </datasetTemplate>
 
 
@@ -198,6 +205,13 @@
             <depends name="${name}_rnaSeq_experiment"/>
             <depends name="${name}_rnaSeq_experiment_CDS"/>
         </subgraph>
+
+        <step name="${name}_rnaSeq_undoEdaStudy"
+              stepClass="ApiCommonWorkflow::Main::WorkflowSteps::UndoEdaStudy">
+            <paramValue name="extDbRlsSpec">${organismAbbrev}_${name}_rnaSeq_RSRC|${version}</paramValue>
+            <paramValue name="gusConfigFile">$$gusConfigFile$$</paramValue>
+            <depends name="${name}_analyze_rnaSeq_experiment"/>
+        </step>
 
   </datasetTemplate>
 


### PR DESCRIPTION
## Summary

- Adds `UndoEdaStudy.pm` WorkflowStep: no-op forward (writes a log file), runs `undoEdaStudy.pl --extDbRlsSpec ... --gusConfigFile ...` on undo and removes the log file
- Adds `${name}_rnaSeq_undoEdaStudy` step to the `rnaSeqExperiment` datasetTemplate in `rnaseq.xml`, depending on `${name}_analyze_rnaSeq_experiment`
- Adds `${name}_ebi_rnaSeq_undoEdaStudy` step to the `ebiRnaSeqExperiment` datasetTemplate in `rnaseq.xml`, depending on `${name}_ebi_rnaSeq_experiment`

## Problem

When undoing a single RNAseq study, EDA metadata rows loaded by sampleDetailsForEda (via StudyDealerNextflow) are left in place by design. This blocks the loadDataset undo because FK constraints still reference the dataset record. This step ensures those rows are cleaned up for the specific study before loadDataset is undone.

## Test plan

- [ ] Run a workflow with a rnaSeqExperiment dataset and confirm the log file is written to the workflow data dir
- [ ] Undo the dataset and confirm undoEdaStudy.pl is called with the correct --extDbRlsSpec and the log file is removed
- [ ] Confirm loadDataset undo completes cleanly after the EDA metadata is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)