### PR TITLE
add NXF_SCRATCH=$LSF_TMPDIR to nextflow configs on LSF cluster

### DIFF
--- a/Main/lib/perl/WorkflowSteps/MakeAntismashNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeAntismashNextflowConfig.pm
@@ -27,6 +27,7 @@ sub run {
     my $digestedResultDir = $self->relativePathToNextflowClusterPath($workingDirRelativePath, $resultDir);
 
     my $executor = $self->getClusterExecutor();
+    my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
     my $queue = $self->getClusterQueue();
 
     if ($undo) {
@@ -51,7 +52,7 @@ singularity {
   autoMounts = true
   runOptions = \"--bind $antismashDatabase:/databases\"
 }
-";
+$lsfEnv";
 	close(F);
     }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeArbaNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeArbaNextflowConfig.pm
@@ -25,6 +25,7 @@ sub run {
     my $digestedOutputDir = $self->relativePathToNextflowClusterPath($workingDirRelativePath, $outputDir);
 
     my $executor = $self->getClusterExecutor();
+    my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
     my $queue = $self->getClusterQueue();
 
     if ($undo) {
@@ -51,7 +52,7 @@ singularity {
   enabled = true
   autoMounts = true
 }
-";
+$lsfEnv";
 	close(F);
     }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeArrayProbeMappingNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeArrayProbeMappingNextflowConfig.pm
@@ -70,6 +70,7 @@ sub run {
   my $clusterServer = $self->getSharedConfig('clusterServer');
   my $clusterWorkflowDataDir = $self->getClusterWorkflowDataDir();
   my $executor = $self->getClusterExecutor();
+  my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
 
   my $clusterConfigFile = "\$baseDir/conf/${executor}.config";
 
@@ -118,7 +119,7 @@ includeConfig "$clusterConfigFile"
 
 NEXTFLOW
 
-      print F $configString;
+      print F $configString . $lsfEnv;
       close(F);
   }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeBlastPPdbNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeBlastPPdbNextflowConfig.pm
@@ -30,6 +30,7 @@ sub run {
 
   my $clusterWorkflowDataDir = $self->getClusterWorkflowDataDir();
   my $executor = $self->getClusterExecutor();
+  my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
 
   my $clusterConfigFile = "\$baseDir/conf/${executor}.config";
 
@@ -67,7 +68,7 @@ includeConfig "$clusterConfigFile"
 
 NEXTFLOW
 
-      print F $configString;
+      print F $configString . $lsfEnv;
       close(F);
   }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeBlastSimilarityNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeBlastSimilarityNextflowConfig.pm
@@ -37,6 +37,7 @@ sub run {
     my $maxRetries = $self->getParamValue("maxRetries");
 
     my $executor = $self->getClusterExecutor();
+    my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
     my $queue = $self->getClusterQueue();
  
     if ($undo) {
@@ -86,7 +87,7 @@ singularity {
   enabled = true
   autoMounts = true
 }
-";
+$lsfEnv";
 	close(F);
     }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeBlatNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeBlatNextflowConfig.pm
@@ -30,6 +30,7 @@ sub run {
     my $maxRetries = $self->getParamValue("maxRetries");
 
     my $executor = $self->getClusterExecutor();
+    my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
     my $queue = $self->getClusterQueue();
 
     my $clusterConfigFile = "\$baseDir/conf/${executor}.config";
@@ -65,7 +66,7 @@ process {
 includeConfig "$clusterConfigFile"
 NEXTFLOW
 
-    print F $configString;
+    print F $configString . $lsfEnv;
     close(F);
     }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeBowtieMappingNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeBowtieMappingNextflowConfig.pm
@@ -31,6 +31,7 @@ sub run {
   my $hasPairedReads = $self->getParamValue("hasPairedEnds");  
 
   my $executor = $self->getClusterExecutor();
+  my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
   my $queue = $self->getClusterQueue();
 
   if ($undo) {
@@ -65,7 +66,7 @@ singularity {
   enabled = true
   autoMounts = true
 }
-";
+$lsfEnv";
   close(F);
  }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeBulkRnaSeqNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeBulkRnaSeqNextflowConfig.pm
@@ -35,6 +35,7 @@ sub run {
   my $clusterServer = $self->getSharedConfig('clusterServer');
   my $clusterWorkflowDataDir = $self->getClusterWorkflowDataDir();
   my $executor = $self->getClusterExecutor();
+  my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
 
   my $clusterConfigFile = "\$baseDir/conf/${executor}.config";
 
@@ -98,7 +99,7 @@ def check_max(obj, type) {
 
 NEXTFLOW
 
-      print F $configString;
+      print F $configString . $lsfEnv;
       close(F);
   }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeBuscoNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeBuscoNextflowConfig.pm
@@ -29,6 +29,7 @@ sub run {
     my $speciesNcbiTaxonId = $self->getParamValue("speciesNcbiTaxonId");
     
     my $executor = $self->getClusterExecutor();
+    my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
     my $clusterConfigFile = "\$baseDir/conf/${executor}.config";
 
     if ($undo) {
@@ -64,7 +65,7 @@ process {
 includeConfig "$clusterConfigFile"
 
 NEXTFLOW
-      print F $configString;
+      print F $configString . $lsfEnv;
       close(F);
     }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeChipSeqNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeChipSeqNextflowConfig.pm
@@ -39,6 +39,7 @@ sub run {
   my $clusterServer = $self->getSharedConfig('clusterServer');
   my $clusterWorkflowDataDir = $self->getClusterWorkflowDataDir();
   my $executor = $self->getClusterExecutor();
+  my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
 
   my $clusterConfigFile = "\$baseDir/conf/${executor}.config";
 
@@ -82,7 +83,7 @@ process {
 
 NEXTFLOW
 
-      print F $configString;
+      print F $configString . $lsfEnv;
       close(F);
   }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeDnaSeqSingleExperimentNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeDnaSeqSingleExperimentNextflowConfig.pm
@@ -43,6 +43,7 @@ sub run {
   my $ebiFtpPassword = $self->getConfig("ebiFtpPassword");  
 
   my $executor = $self->getClusterExecutor();
+  my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
   my $queue = $self->getClusterQueue();
 
   my $gusConfigFile = $ENV{GUS_HOME}."/config/gus.config";
@@ -120,7 +121,7 @@ singularity {
   enabled = true
   autoMounts = true
 }
-";
+$lsfEnv";
   close(F);
  }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeDustNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeDustNextflowConfig.pm
@@ -25,6 +25,7 @@ sub run {
   my $clusterServer = $self->getSharedConfig('clusterServer');
   my $clusterWorkflowDataDir = $self->getClusterWorkflowDataDir();
   my $executor = $self->getClusterExecutor();
+  my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
 
   my $clusterConfigFile = "\$baseDir/conf/${executor}.config";
 
@@ -47,7 +48,7 @@ includeConfig "$clusterConfigFile"
 
 NEXTFLOW
 
-      print F $configString;
+      print F $configString . $lsfEnv;
       close(F);
   }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeEpitopeMappingNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeEpitopeMappingNextflowConfig.pm
@@ -35,6 +35,7 @@ sub run {
 
     my $clusterWorkflowDataDir = $self->getClusterWorkflowDataDir();
     my $executor = $self->getClusterExecutor();
+    my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
     my $clusterConfigFile = "\$baseDir/conf/${executor}.config";
 
     if ($undo) {
@@ -89,7 +90,7 @@ includeConfig "$clusterConfigFile"
 
 NEXTFLOW
 
-        print F $configString;
+        print F $configString . $lsfEnv;
         close(F);
     }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeExportpredNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeExportpredNextflowConfig.pm
@@ -20,6 +20,7 @@ sub run {
 
     my $clusterWorkflowDataDir = $self->getClusterWorkflowDataDir();
   my $executor = $self->getClusterExecutor();
+  my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
 
   my $clusterConfigFile = "\$baseDir/conf/${executor}.config";
 
@@ -48,7 +49,7 @@ includeConfig "$clusterConfigFile"
 
 NEXTFLOW
 
-      print F $configString;
+      print F $configString . $lsfEnv;
       close(F);
   }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeGenomicArrayExperimentNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeGenomicArrayExperimentNextflowConfig.pm
@@ -46,6 +46,7 @@ sub run {
 
   my $clusterWorkflowDataDir = $self->getClusterWorkflowDataDir();
   my $executor = $self->getClusterExecutor();
+  my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
 
   my $clusterConfigFile = "\$baseDir/conf/${executor}.config";
 
@@ -75,7 +76,7 @@ includeConfig "$clusterConfigFile"
 
 NEXTFLOW
 
-      print F $configString;
+      print F $configString . $lsfEnv;
       close(F);
   }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeIprscan5NextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeIprscan5NextflowConfig.pm
@@ -24,6 +24,7 @@ sub run {
     my $digestedOutputDir = $self->relativePathToNextflowClusterPath($workingDirRelativePath, $outputDir);
 
     my $executor = $self->getClusterExecutor();
+    my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
     my $queue = $self->getClusterQueue();
 
     if ($undo) {
@@ -61,7 +62,7 @@ singularity {
   autoMounts = true
   runOptions = \"--bind $interproscanDatabase:/opt/interproscan/data --bind $interproscanDatabase/interproscan.properties:/opt/interproscan/interproscan.properties\" 
 }
-";
+$lsfEnv";
 	close(F);
     }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeLongReadRnaSeqNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeLongReadRnaSeqNextflowConfig.pm
@@ -41,6 +41,7 @@ sub run {
     my $clusterServer = $self->getSharedConfig('clusterServer');
     my $clusterWorkflowDataDir = $self->getClusterWorkflowDataDir();
     my $executor = $self->getClusterExecutor();
+    my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
 
     my $clusterConfigFile = "\$baseDir/conf/${executor}.config";
 
@@ -68,7 +69,7 @@ params {
 
 includeConfig \"$clusterConfigFile\"
 
- ";
+ $lsfEnv";
 
         close(F);
 

--- a/Main/lib/perl/WorkflowSteps/MakeMassSpecNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeMassSpecNextflowConfig.pm
@@ -33,6 +33,7 @@ sub run {
 
   my $clusterWorkflowDataDir = $self->getClusterWorkflowDataDir();
   my $executor = $self->getClusterExecutor();
+  my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
 
   my $clusterConfigFile = "\$baseDir/conf/${executor}.config";
 
@@ -61,7 +62,7 @@ includeConfig "$clusterConfigFile"
 
 NEXTFLOW
 
-      print F $configString;
+      print F $configString . $lsfEnv;
       close(F);
   }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeNgsSamplesNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeNgsSamplesNextflowConfig.pm
@@ -33,6 +33,7 @@ sub run {
   my $clusterServer = $self->getSharedConfig('clusterServer');
   my $clusterWorkflowDataDir = $self->getClusterWorkflowDataDir();
   my $executor = $self->getClusterExecutor();
+  my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
 
   my $clusterConfigFile = "\$baseDir/conf/${executor}.config";
 
@@ -67,7 +68,7 @@ workDir = "$digestedAnalysisDirPath/ngs-samples-work"
 
 NEXTFLOW
 
-      print F $configString;
+      print F $configString . $lsfEnv;
       close(F);
   }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeOriginsOfReplicationNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeOriginsOfReplicationNextflowConfig.pm
@@ -37,6 +37,7 @@ sub run {
   my $clusterServer = $self->getSharedConfig('clusterServer');
   my $clusterWorkflowDataDir = $self->getClusterWorkflowDataDir();
   my $executor = $self->getClusterExecutor();
+  my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
 
   my $clusterConfigFile = "\$baseDir/conf/${executor}.config";
 
@@ -81,7 +82,7 @@ process {
 
 NEXTFLOW
 
-      print F $configString;
+      print F $configString . $lsfEnv;
       close(F);
   }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeOrthoFinderCoreNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeOrthoFinderCoreNextflowConfig.pm
@@ -30,6 +30,7 @@ sub run {
   my $configPath = join("/", $self->getWorkflowDataDir(),  $self->getParamValue("analysisDir"), $self->getParamValue("configFileName"));
 
   my $executor = $self->getClusterExecutor();
+  my $lsfScratch = ($executor eq 'lsf') ? "\n  NXF_SCRATCH = '\$LSF_TMPDIR'" : '';
   my $queue = $self->getClusterQueue();
 
   if ($undo) {
@@ -73,7 +74,7 @@ process {
 env {
   _JAVA_OPTIONS=\"-Xmx8192M\"
   NXF_OPTS=\"-Xmx8192M\"
-  NXF_JVM_ARGS=\"-Xmx8192M\"
+  NXF_JVM_ARGS=\"-Xmx8192M\"$lsfScratch
 }
 
 singularity {

--- a/Main/lib/perl/WorkflowSteps/MakeOrthoFinderPeripheralEntryNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeOrthoFinderPeripheralEntryNextflowConfig.pm
@@ -36,6 +36,7 @@ sub run {
   my $resultsDirectoryInNextflowWorkingDirOnCluster = $self->relativePathToNextflowClusterPath($workingDirRelativePath, $resultsDirectory);
 
   my $executor = $self->getClusterExecutor();
+  my $lsfScratch = ($executor eq 'lsf') ? "\n  NXF_SCRATCH = '\$LSF_TMPDIR'" : '';
   my $queue = $self->getClusterQueue();
 
   if ($undo) {
@@ -74,7 +75,7 @@ process {
 env {
   _JAVA_OPTIONS=\"-Xmx8192M\"
   NXF_OPTS=\"-Xmx8192M\"
-  NXF_JVM_ARGS=\"-Xmx8192M\"
+  NXF_JVM_ARGS=\"-Xmx8192M\"$lsfScratch
 }
 
 singularity {

--- a/Main/lib/perl/WorkflowSteps/MakeOrthoFinderPostProcessingEntryNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeOrthoFinderPostProcessingEntryNextflowConfig.pm
@@ -41,6 +41,7 @@ sub run {
   my $resultsDirectoryInNextflowWorkingDirOnCluster = $self->relativePathToNextflowClusterPath($workingDirRelativePath, $resultsDirectory);
 
   my $executor = $self->getClusterExecutor();
+  my $lsfScratch = ($executor eq 'lsf') ? "\n  NXF_SCRATCH = '\$LSF_TMPDIR'" : '';
   my $queue = $self->getClusterQueue();
 
   if ($undo) {
@@ -73,7 +74,7 @@ process {
 env {
   _JAVA_OPTIONS=\"-Xmx8192M\"
   NXF_OPTS=\"-Xmx8192M\"
-  NXF_JVM_ARGS=\"-Xmx8192M\"
+  NXF_JVM_ARGS=\"-Xmx8192M\"$lsfScratch
 }
 
 singularity {

--- a/Main/lib/perl/WorkflowSteps/MakeOrthoFinderPostResidualEntryNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeOrthoFinderPostResidualEntryNextflowConfig.pm
@@ -32,6 +32,7 @@ sub run {
   my $resultsDirectoryInNextflowWorkingDirOnCluster = $self->relativePathToNextflowClusterPath($workingDirRelativePath, $resultsDirectory);
 
   my $executor = $self->getClusterExecutor();
+  my $lsfScratch = ($executor eq 'lsf') ? "\n  NXF_SCRATCH = '\$LSF_TMPDIR'" : '';
   my $queue = $self->getClusterQueue();
 
   if ($undo) {
@@ -60,7 +61,7 @@ process {
 env {
   _JAVA_OPTIONS=\"-Xmx8192M\"
   NXF_OPTS=\"-Xmx8192M\"
-  NXF_JVM_ARGS=\"-Xmx8192M\"
+  NXF_JVM_ARGS=\"-Xmx8192M\"$lsfScratch
 }
 
 singularity {

--- a/Main/lib/perl/WorkflowSteps/MakeOrthoFinderResidualEntryNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeOrthoFinderResidualEntryNextflowConfig.pm
@@ -22,6 +22,7 @@ sub run {
   my $resultsDirectoryInNextflowWorkingDirOnCluster = $self->relativePathToNextflowClusterPath($workingDirRelativePath, $resultsDirectory);
 
   my $executor = $self->getClusterExecutor();
+  my $lsfScratch = ($executor eq 'lsf') ? "\n  NXF_SCRATCH = '\$LSF_TMPDIR'" : '';
   my $queue = $self->getClusterQueue();
 
   if ($undo) {
@@ -46,7 +47,7 @@ process {
 env {
   _JAVA_OPTIONS=\"-Xmx8192M\"
   NXF_OPTS=\"-Xmx8192M\"
-  NXF_JVM_ARGS=\"-Xmx8192M\"
+  NXF_JVM_ARGS=\"-Xmx8192M\"$lsfScratch
 }
 
 singularity {

--- a/Main/lib/perl/WorkflowSteps/MakeProteinAttributesNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeProteinAttributesNextflowConfig.pm
@@ -22,6 +22,7 @@ sub run {
   my $clusterServer = $self->getSharedConfig('clusterServer');
   my $clusterWorkflowDataDir = $self->getClusterWorkflowDataDir();
   my $executor = $self->getClusterExecutor();
+  my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
 
   my $clusterConfigFile = "\$baseDir/conf/${executor}.config";
 
@@ -47,7 +48,7 @@ includeConfig "$clusterConfigFile"
 
 NEXTFLOW
 
-      print F $configString;
+      print F $configString . $lsfEnv;
       close(F);
   }
 }

--- a/Main/lib/perl/WorkflowSteps/MakePsiPredNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakePsiPredNextflowConfig.pm
@@ -22,6 +22,7 @@ sub run {
     my $workingDirRelativePath = $self->getParamValue("workingDirRelativePath");
 
     my $executor = $self->getClusterExecutor();
+    my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
     my $clusterConfigFile = "\$baseDir/conf/${executor}.config";
 
     if ($undo) {
@@ -53,7 +54,7 @@ process {
 includeConfig "$clusterConfigFile"
 
 NEXTFLOW
-      print F $configString;
+      print F $configString . $lsfEnv;
 	close(F);
     }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeRepeatMaskerNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeRepeatMaskerNextflowConfig.pm
@@ -38,6 +38,7 @@ sub run {
     my $repeatMaskerDatabase = join("/", $self->getSharedConfig("$clusterServer.softwareDatabasesDirectory"),$self->getSharedConfig("repeatMaskerDatabaseDirectory"),$famdbRelativePath);
 
     my $executor = $self->getClusterExecutor();
+    my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
     my $clusterConfigFile = "\$baseDir/conf/${executor}.config";
 
     my $organismAbbrev = $self->getParamValue('organismAbbrev');
@@ -84,7 +85,7 @@ singularity {
 
 
 NEXTFLOW
-    print F $configString;
+    print F $configString . $lsfEnv;
     close(F);
 
     }

--- a/Main/lib/perl/WorkflowSteps/MakeSegNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeSegNextflowConfig.pm
@@ -21,6 +21,7 @@ sub run {
   my $clusterServer = $self->getSharedConfig('clusterServer');
   my $clusterWorkflowDataDir = $self->getClusterWorkflowDataDir();
   my $executor = $self->getClusterExecutor();
+  my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
 
   my $clusterConfigFile = "\$baseDir/conf/${executor}.config";
 
@@ -46,7 +47,7 @@ includeConfig "$clusterConfigFile"
 
 NEXTFLOW
 
-      print F $configString;
+      print F $configString . $lsfEnv;
       close(F);
   }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeSignalPNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeSignalPNextflowConfig.pm
@@ -35,6 +35,7 @@ sub run {
 
   my $clusterWorkflowDataDir = $self->getClusterWorkflowDataDir();
   my $executor = $self->getClusterExecutor();
+  my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
 
   my $clusterConfigFile = "\$baseDir/conf/${executor}.config";
 
@@ -76,7 +77,7 @@ includeConfig "$clusterConfigFile"
 
 NEXTFLOW
 
-      print F $configString;
+      print F $configString . $lsfEnv;
       close(F);
   }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeSplicedLeaderAndPolyASitesNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeSplicedLeaderAndPolyASitesNextflowConfig.pm
@@ -36,6 +36,7 @@ sub run {
   my $clusterServer = $self->getSharedConfig('clusterServer');
   my $clusterWorkflowDataDir = $self->getClusterWorkflowDataDir();
   my $executor = $self->getClusterExecutor();
+  my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
 
   my $clusterConfigFile = "\$baseDir/conf/${executor}.config";
 
@@ -76,7 +77,7 @@ process {
 
 NEXTFLOW
 
-      print F $configString;
+      print F $configString . $lsfEnv;
       close(F);
   }
 }

--- a/Main/lib/perl/WorkflowSteps/MakeTmhmmNextflowConfig.pm
+++ b/Main/lib/perl/WorkflowSteps/MakeTmhmmNextflowConfig.pm
@@ -28,6 +28,7 @@ sub run {
 
   my $clusterWorkflowDataDir = $self->getClusterWorkflowDataDir();
   my $executor = $self->getClusterExecutor();
+  my $lsfEnv = $self->getNextflowLsfScratchEnvBlock();
 
   my $clusterConfigFile = "\$baseDir/conf/${executor}.config";
 
@@ -61,7 +62,7 @@ includeConfig "$clusterConfigFile"
 
 NEXTFLOW
 
-      print F $configString;
+      print F $configString . $lsfEnv;
       close(F);
   }
 }

--- a/Main/lib/perl/WorkflowSteps/WorkflowStep.pm
+++ b/Main/lib/perl/WorkflowSteps/WorkflowStep.pm
@@ -345,6 +345,12 @@ sub getClusterExecutor {
   die "Could not determine executor for nodeClass $nodeClass";
 }
 
+sub getNextflowLsfScratchEnvBlock {
+  my ($self) = @_;
+  return '' unless $self->getClusterExecutor() eq 'lsf';
+  return "\nenv {\n  NXF_SCRATCH = '\$LSF_TMPDIR'\n}\n";
+}
+
 
 sub runSqlFetchOneRowFromOrgDb {
     my ($self, $test, $sql, $dbh) = @_;


### PR DESCRIPTION
## Summary
- Added `getNextflowLsfScratchEnvBlock()` helper to `WorkflowStep.pm` that returns `env { NXF_SCRATCH = '$LSF_TMPDIR' }` when the executor is LSF, empty string otherwise
- Updated all 32 `Make*NextflowConfig` workflow steps to include this block in the generated `nextflow.config` when running on LSF
- OrthoFinder configs (which already had an `env {}` block with JVM settings) have `NXF_SCRATCH` inserted inline into the existing block rather than as a separate block
- 4 always-local config steps (`MakeLoadCNVNextflowConfig`, `MakeDnaSeqMergeExperimentsNextflowConfig`, `MakeStudyAssayResultsNextflowConfig`, `MakeRnaSeqAnalysisNextflowConfig`) are unchanged

## Test plan
- [ ] Run a nextflow workflow on LSF and confirm the generated `nextflow.config` contains `NXF_SCRATCH = '$LSF_TMPDIR'`
- [ ] Run a nextflow workflow locally and confirm the generated config does NOT contain `NXF_SCRATCH`
- [ ] Verify OrthoFinder config on LSF has `NXF_SCRATCH` inside the single `env {}` block alongside the JVM settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)